### PR TITLE
Copy icon cleanly and remove opus

### DIFF
--- a/org.gnome.EasyTAG.yaml
+++ b/org.gnome.EasyTAG.yaml
@@ -17,7 +17,7 @@ cleanup:
   - /lib/pkgconfig
   - /lib/*.a
   - /lib/*.la
-rename-icon: easytag
+copy-icon: easytag
 rename-desktop-file: easytag.desktop
 rename-appdata-file: easytag.appdata.xml
 
@@ -72,26 +72,6 @@ modules:
       - type: script
         commands:
           - autoreconf --force --install
-
-  - name: opus
-    cleanup:
-      - /share/aclocal
-    config-opts:
-      - --disable-doc
-      - --disable-extra-programs
-    sources:
-      - type: archive
-        url: https://archive.mozilla.org/pub/opus/opus-1.3.1.tar.gz
-        sha512: 6cd5e4d8a0551ed5fb59488c07a5cc18a241d1fde5f9eb9f16cd4e77abcdb4134dd51ad1d737be1e6039bfa56912510b8648152f2478a1f21c7c1d9ce32933cd
-
-  - name: opusfile
-    config-opts:
-      - --disable-doc
-      - --disable-examples
-    sources:
-      - type: archive
-        url: https://downloads.xiph.org/releases/opus/opusfile-0.12.tar.gz
-        sha512: e25e6968a3183ac0628ce1000840fd6f9f636e92ba984d6a72b76fb2a98ec632d2de4c66a8e4c05ef30655c2a4a13ab35f89606fa7d79a54cfa8506543ca57af
 
   - name: taglib
     buildsystem: cmake

--- a/org.gnome.EasyTAG.yaml
+++ b/org.gnome.EasyTAG.yaml
@@ -17,7 +17,8 @@ cleanup:
   - /lib/pkgconfig
   - /lib/*.a
   - /lib/*.la
-copy-icon: easytag
+rename-icon: easytag
+copy-icon: true
 rename-desktop-file: easytag.desktop
 rename-appdata-file: easytag.appdata.xml
 


### PR DESCRIPTION
Copy icon is needed so the about dialog doesn't show a broken icon (didn't know there's a built in function before), also opus is in the runtime already.