### PR TITLE
Update to GNOME 45 runtime and TagLib 1.13.1

### DIFF
--- a/org.gnome.EasyTAG.yaml
+++ b/org.gnome.EasyTAG.yaml
@@ -1,6 +1,6 @@
 id: org.gnome.EasyTAG
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '45'
 sdk: org.gnome.Sdk
 command: easytag
 finish-args:
@@ -80,8 +80,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://taglib.org/releases/taglib-1.13.tar.gz
-        sha512: b6e3253d158b41173073c0da1915f5e4a3de947db918660817cb1c755fba7e3723ea1a335fbbc30b0dcf942348a471b493fe2ce1d52d1a808578edee14e1bfc7
+        url: https://taglib.org/releases/taglib-1.13.1.tar.gz
+        sha512: 986231ee62caa975afead7e94630d58acaac25a38bc33d4493d51bd635d79336e81bba60586d7355ebc0670e31f28d32da3ecceaf33292e4bc240c64bf00f35b
 
   - name: intltool
     cleanup:


### PR DESCRIPTION
TagLib 2.0 is also available now but EasyTAG isn't compatible due to use of deprecated API.