### PR TITLE
Update runtime to 49

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -9,10 +9,11 @@ diff --color -ura easytag-2.4.3/data/easytag.appdata.xml.in easytag-2.4.3-patche
      <description>
          <_p>View and edit tags for MP3, MP2, MP4/AAC, FLAC, Ogg Opus, Ogg
          Speex, Ogg Vorbis, MusePack, Monkey's Audio and WavPack files.</_p>
-@@ -19,15 +20,21 @@
+@@ -19,15 +20,22 @@
      <url type="homepage">https://wiki.gnome.org/Apps/EasyTAG</url>
      <url type="bugtracker">https://bugzilla.gnome.org/enter_bug.cgi?product=easytag</url>
      <url type="help">https://help.gnome.org/users/easytag/stable/</url>
++    <url type="vcs-browser">https://gitlab.gnome.org/GNOME/easytag</url>
 +    <launchable type="desktop-id">org.gnome.EasyTAG.desktop</launchable>
      <screenshots>
          <screenshot type="default">

--- a/org.gnome.EasyTAG.yaml
+++ b/org.gnome.EasyTAG.yaml
@@ -1,6 +1,6 @@
 id: org.gnome.EasyTAG
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 command: easytag
 finish-args:
@@ -76,6 +76,8 @@ modules:
 
   - name: taglib
     buildsystem: cmake
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     cleanup:
       - /bin
     sources:
@@ -94,6 +96,8 @@ modules:
   - name: easytag
     config-opts:
       - --disable-Werror
+    build-options:
+      cflags: -std=gnu11
     sources:
       - type: archive
         url: https://download.gnome.org/sources/easytag/2.4/easytag-2.4.3.tar.xz


### PR DESCRIPTION
Also fix build issue with taglib as well as EasyTAG itself.

Upstream EasyTAG issue: https://gitlab.gnome.org/GNOME/easytag/-/issues/109

EasyTAG build flag taken from Arch Linux package: https://gitlab.archlinux.org/archlinux/packaging/packages/easytag/-/commit/f4ba7c15201825db53aaa3b4f28e1bb1e061cb51